### PR TITLE
Fixing min max range checking.  By all appearances javascript was com…

### DIFF
--- a/api/src/main/java/io/mifos/portfolio/api/v1/domain/BalanceRange.java
+++ b/api/src/main/java/io/mifos/portfolio/api/v1/domain/BalanceRange.java
@@ -25,7 +25,7 @@ import java.util.Objects;
  * @author Myrle Krantz
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
-@ScriptAssert(lang = "javascript", script = "_this.maximum > _this.minimum && _this.minimum.scale() <= 4 && _this.maximum.scale() <= 4")
+@ScriptAssert(lang = "javascript", script = "_this.maximum != null && _this.minimum != null && _this.maximum.compareTo(_this.minimum) >= 0 && _this.minimum.scale() <= 4 && _this.maximum.scale() <= 4")
 public final class BalanceRange {
   @Range(min = 0)
   private BigDecimal minimum;

--- a/api/src/main/java/io/mifos/portfolio/api/v1/domain/InterestRange.java
+++ b/api/src/main/java/io/mifos/portfolio/api/v1/domain/InterestRange.java
@@ -25,7 +25,7 @@ import java.math.BigDecimal;
  * @author Myrle Krantz
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
-@ScriptAssert(lang = "javascript", script = "_this.maximum > _this.minimum && _this.minimum.scale() == 2 && _this.maximum.scale() == 2")
+@ScriptAssert(lang = "javascript", script = "_this.maximum != null && _this.minimum != null && _this.maximum.compareTo(_this.minimum) >= 0 && _this.minimum.scale() == 2 && _this.maximum.scale() == 2")
 public class InterestRange {
   @DecimalMin(value = "0.00")
   @DecimalMax(value = "999.99")

--- a/api/src/test/java/io/mifos/portfolio/api/v1/domain/BalanceRangeTest.java
+++ b/api/src/test/java/io/mifos/portfolio/api/v1/domain/BalanceRangeTest.java
@@ -54,6 +54,18 @@ public class BalanceRangeTest extends ValidationTest<BalanceRange> {
     ret.add(new ValidationTestCase<BalanceRange>("minLargerthanMax")
             .adjustment((x) -> x.setMinimum(BigDecimal.TEN.multiply(BigDecimal.TEN)))
             .valid(false));
+    ret.add(new ValidationTestCase<BalanceRange>("5 and 10")
+            .adjustment(x -> {
+              x.setMinimum(BigDecimal.valueOf(5L).setScale(2, BigDecimal.ROUND_UNNECESSARY));
+              x.setMaximum(BigDecimal.valueOf(10L).setScale(2, BigDecimal.ROUND_UNNECESSARY));
+            })
+            .valid(true));
+    ret.add(new ValidationTestCase<BalanceRange>("5 and 5")
+            .adjustment(x -> {
+              x.setMinimum(BigDecimal.valueOf(5L).setScale(2, BigDecimal.ROUND_UNNECESSARY));
+              x.setMaximum(BigDecimal.valueOf(5L).setScale(2, BigDecimal.ROUND_UNNECESSARY));
+            })
+            .valid(true));
     return ret;
   }
 }

--- a/api/src/test/java/io/mifos/portfolio/api/v1/domain/InterestRangeTest.java
+++ b/api/src/test/java/io/mifos/portfolio/api/v1/domain/InterestRangeTest.java
@@ -1,0 +1,59 @@
+package io.mifos.portfolio.api.v1.domain;
+
+import io.mifos.core.test.domain.ValidationTest;
+import io.mifos.core.test.domain.ValidationTestCase;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Myrle Krantz
+ */
+@RunWith(Parameterized.class)
+public class InterestRangeTest extends ValidationTest<InterestRange> {
+  public InterestRangeTest(ValidationTestCase<InterestRange> testCase) {
+    super(testCase);
+  }
+
+  @Override
+  protected InterestRange createValidTestSubject() {
+    return new InterestRange(BigDecimal.valueOf(0.02d).setScale(2, BigDecimal.ROUND_UNNECESSARY),
+            BigDecimal.valueOf(0.03d).setScale(2, BigDecimal.ROUND_UNNECESSARY));
+  }
+
+  @Parameterized.Parameters
+  public static Collection testCases() {
+    final Collection<ValidationTestCase> ret = new ArrayList<>();
+    ret.add(new ValidationTestCase<InterestRange>("basicCase")
+            .adjustment(x -> {})
+            .valid(true));
+    ret.add(new ValidationTestCase<InterestRange>("5 and 10")
+            .adjustment(x -> {
+              x.setMinimum(BigDecimal.valueOf(5L).setScale(2, BigDecimal.ROUND_UNNECESSARY));
+              x.setMaximum(BigDecimal.valueOf(10L).setScale(2, BigDecimal.ROUND_UNNECESSARY));
+            })
+            .valid(true));
+    ret.add(new ValidationTestCase<InterestRange>("5 and 5")
+            .adjustment(x -> {
+              x.setMinimum(BigDecimal.valueOf(5L).setScale(2, BigDecimal.ROUND_UNNECESSARY));
+              x.setMaximum(BigDecimal.valueOf(5L).setScale(2, BigDecimal.ROUND_UNNECESSARY));
+            })
+            .valid(true));
+    ret.add(new ValidationTestCase<InterestRange>("maxNull")
+            .adjustment((x) -> x.setMaximum(null))
+            .valid(false));
+    ret.add(new ValidationTestCase<InterestRange>("maximim smaller than minimum")
+            .adjustment(x -> {
+              x.setMinimum(BigDecimal.valueOf(10L).setScale(2, BigDecimal.ROUND_UNNECESSARY));
+              x.setMaximum(BigDecimal.valueOf(5L).setScale(2, BigDecimal.ROUND_UNNECESSARY));
+            })
+            .valid(false));
+    return ret;
+  }
+
+}


### PR DESCRIPTION
…paring object references instead of calling java .compareTo.  null value shouldn't cause a npe, and equal min and max should be allowed.