### PR TITLE
Migration on a deployment failed because it was done using a portfoli…

### DIFF
--- a/service/src/main/resources/db/migrations/mariadb/V4__fixing_in_motion_migration.sql
+++ b/service/src/main/resources/db/migrations/mariadb/V4__fixing_in_motion_migration.sql
@@ -14,6 +14,4 @@
 -- limitations under the License.
 --
 
-# noinspection SqlNoDataSourceInspectionForFile
-
-ALTER TABLE bastet_p_chrg_defs ADD COLUMN proportional_to VARCHAR(32) NULL DEFAULT NULL;
+ALTER TABLE bastet_cases ADD COLUMN end_of_term TIMESTAMP(3) NULL DEFAULT NULL;


### PR DESCRIPTION
…o artifact which contained only a partial "in_motion" migration. The part it didn't contain needs to be moved into its own migration script.